### PR TITLE
fix bug where load csv code generation would only work for api implementation

### DIFF
--- a/neo4j_runway/tests/resources/ingestion_generation_answers.py
+++ b/neo4j_runway/tests/resources/ingestion_generation_answers.py
@@ -28,7 +28,7 @@ MATCH (source:NodeA {{uniqueProp1: row.unique_prop_1, uniqueProp3: row.unique_pr
 MATCH (target:NodeB {{uniqueProp2: row.unique_prop_2}})
 MERGE (source)-[n:HAS_RELATIONSHIP]->(target)
 {set_properties_rel_1}"""
-merge_relationship_load_csv = f"""LOAD CSV WITH HEADERS FROM 'file:///test.csv' as row
+merge_relationship_load_csv = f""":auto LOAD CSV WITH HEADERS FROM 'file:///test.csv' as row
 CALL {{
     WITH row
     MATCH (source:NodeA {{uniqueProp1: row.unique_prop_1, uniqueProp3: row.unique_prop_3}})

--- a/neo4j_runway/tests/resources/people-pets-arrows-for-load-csv.json
+++ b/neo4j_runway/tests/resources/people-pets-arrows-for-load-csv.json
@@ -1,0 +1,166 @@
+{
+  "style": {
+    "font-family": "sans-serif",
+    "background-color": "#ffffff",
+    "background-image": "",
+    "background-size": "100%",
+    "node-color": "#ffffff",
+    "border-width": 4,
+    "border-color": "#000000",
+    "radius": 50,
+    "node-padding": 5,
+    "node-margin": 2,
+    "outside-position": "auto",
+    "node-icon-image": "",
+    "node-background-image": "",
+    "icon-position": "inside",
+    "icon-size": 64,
+    "caption-position": "inside",
+    "caption-max-width": 200,
+    "caption-color": "#000000",
+    "caption-font-size": 50,
+    "caption-font-weight": "normal",
+    "label-position": "inside",
+    "label-display": "pill",
+    "label-color": "#000000",
+    "label-background-color": "#ffffff",
+    "label-border-color": "#000000",
+    "label-border-width": 4,
+    "label-font-size": 40,
+    "label-padding": 5,
+    "label-margin": 4,
+    "directionality": "directed",
+    "detail-position": "inline",
+    "detail-orientation": "parallel",
+    "arrow-width": 5,
+    "arrow-color": "#000000",
+    "margin-start": 5,
+    "margin-end": 5,
+    "margin-peer": 20,
+    "attachment-start": "normal",
+    "attachment-end": "normal",
+    "relationship-icon-image": "",
+    "type-color": "#000000",
+    "type-background-color": "#ffffff",
+    "type-border-color": "#000000",
+    "type-border-width": 0,
+    "type-font-size": 16,
+    "type-padding": 5,
+    "property-position": "outside",
+    "property-alignment": "colon",
+    "property-color": "#000000",
+    "property-font-size": 16,
+    "property-font-weight": "normal"
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "position": {
+        "x": 209.43364843656647,
+        "y": -279.86295267473423
+      },
+      "caption": "name",
+      "labels": [
+        "Person"
+      ],
+      "properties": {
+        "name": "name | str",
+        "age": "age | int"
+      },
+      "style": {
+        "outside-position": "bottom",
+        "node-color": "#68bc00"
+      }
+    },
+    {
+      "id": "n1",
+      "position": {
+        "x": 572.2331024161601,
+        "y": -180.66469660748788
+      },
+      "caption": "address",
+      "labels": [
+        "Address"
+      ],
+      "properties": {
+        "address": "address | str"
+      },
+      "style": {
+        "node-color": "#fda1ff",
+        "outside-position": "bottom"
+      }
+    },
+    {
+      "id": "n2",
+      "position": {
+        "x": 572.2331024161601,
+        "y": -379.06120874198064
+      },
+      "caption": "name",
+      "labels": [
+        "Pet"
+      ],
+      "properties": {
+        "name": "pet_name | str",
+        "kind": "pet | str"
+      },
+      "style": {
+        "node-color": "#68ccca"
+      }
+    },
+    {
+      "id": "n3",
+      "position": {
+        "x": 900.26386884154,
+        "y": -279.86295267473423
+      },
+      "caption": "name",
+      "labels": [
+        "Toy"
+      ],
+      "properties": {
+        "name": "toy | str",
+        "kind": "toy_type | str"
+      },
+      "style": {
+        "node-color": "#aea1ff",
+        "outside-position": "bottom"
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "id": "n0",
+      "fromId": "n0",
+      "toId": "n1",
+      "type": "HAS_ADDRESS",
+      "properties": {},
+      "style": {
+        "detail-orientation": "horizontal",
+        "detail-position": "inline"
+      }
+    },
+    {
+      "id": "n2",
+      "fromId": "n0",
+      "toId": "n2",
+      "type": "HAS_PET",
+      "properties": {},
+      "style": {
+        "detail-orientation": "horizontal",
+        "detail-position": "inline"
+      }
+    },
+    {
+      "id": "n3",
+      "fromId": "n2",
+      "toId": "n3",
+      "type": "PLAYS_WITH",
+      "properties": {},
+      "style": {
+        "detail-orientation": "horizontal",
+        "detail-position": "inline"
+      }
+    }
+  ]
+}

--- a/neo4j_runway/tests/test_ingest_generation.py
+++ b/neo4j_runway/tests/test_ingest_generation.py
@@ -181,7 +181,9 @@ class TestIngestCodeGneration(unittest.TestCase):
         """
 
         self.assertEqual(
-            generate_merge_node_load_csv_clause(node=self.node_b, csv_name="test.csv"),
+            generate_merge_node_load_csv_clause(
+                node=self.node_b, csv_name="test.csv", method="api"
+            ),
             merge_node_load_csv_b,
         )
 
@@ -210,6 +212,7 @@ class TestIngestCodeGneration(unittest.TestCase):
                 source_node=self.node_a,
                 target_node=self.node_b,
                 csv_name="test.csv",
+                method="browser",
                 batch_size=50,
             ),
             merge_relationship_load_csv,

--- a/neo4j_runway/tests/test_load_csv_via_api.py
+++ b/neo4j_runway/tests/test_load_csv_via_api.py
@@ -1,0 +1,147 @@
+import os
+import unittest
+
+from dotenv import load_dotenv
+from neo4j import GraphDatabase
+from neo4j.exceptions import AuthError
+
+from ..utils import test_database_connection
+from ..ingestion import IngestionGenerator
+from ..objects import DataModel
+
+load_dotenv()
+
+# These credentials are for the dummy data testing only. Do NOT use the same credentials here for production graphs.
+username = os.environ.get("NEO4J_USERNAME")
+password = os.environ.get("NEO4J_PASSWORD")
+uri = os.environ.get("NEO4J_URI")
+database = os.environ.get("NEO4J_DATABASE")
+
+
+class TestLoadCSVViaAPI(unittest.TestCase):
+    """
+    Steps:
+        1. Ensure local instance of Neo4j is available.
+        2. Generate the LOAD CSV code with an imported data model from arrows.app.
+        3. Load the data into a local instance of Neo4j. The csv is located at imports/ of the local instance.
+        4. query local graph to ensure data loaded properly.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.driver = GraphDatabase.driver(
+            uri=uri,
+            auth=(username, password),
+        )
+
+        connection_info = test_database_connection(
+            credentials={
+                "uri": uri,
+                "username": username,
+                "password": password,
+            }
+        )
+
+        if not connection_info["valid"]:
+            raise AuthError(connection_info["message"])
+
+        # clear all data in the database
+        with cls.driver.session(database=database) as session:
+            session.run(
+                """
+                        match (n)-[r]-()
+                        detach delete n, r
+                        ;
+                        """
+            )
+            session.run(
+                """
+                        match (n)
+                        delete n
+                        ;
+                        """
+            )
+            session.run(
+                """
+                        CALL apoc.schema.assert({}, {})
+                        ;
+                        """
+            )
+
+        data_model = DataModel.from_arrows(
+            "neo4j_runway/tests/resources/people-pets-arrows-for-load-csv.json"
+        )
+
+        gen = IngestionGenerator(
+            data_model=data_model,
+            username=username,
+            password=password,
+            uri=uri,
+            database=database,
+            csv_name="pets-arrows.csv",
+        )
+
+        load_csv_cypher = gen.generate_load_csv_string(method="api")
+
+        # skip last "query" since it is an empty string
+        for query in load_csv_cypher.split(";")[:-1]:
+            with cls.driver.session(database=database) as session:
+                session.run(query=query)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.driver.close()
+
+    def test_person_node_count(self) -> None:
+        person_cypher = "match (p:Person) return count(p)"
+        with self.driver.session(database=database) as session:
+            r = session.run(person_cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_pet_node_count(self) -> None:
+        pet_cypher = "match (p:Pet) return count(p)"
+        with self.driver.session(database=database) as session:
+            r = session.run(pet_cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_toy_node_count(self) -> None:
+        toy_cypher = "match (p:Toy) return count(p)"
+        with self.driver.session(database=database) as session:
+            r = session.run(toy_cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_address_node_count(self) -> None:
+        address_cypher = "match (p:Address) return count(p)"
+        with self.driver.session(database=database) as session:
+            r = session.run(address_cypher).single().value()
+            self.assertEqual(3, r)
+
+    def test_person_to_pet_relationship_counts(self) -> None:
+        cypher = "match (:Person)-[r:HAS_PET]-(:Pet) return count(r)"
+        with self.driver.session(database=database) as session:
+            r = session.run(cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_person_to_address_relationship_counts(self) -> None:
+        cypher = "match (:Person)-[r:HAS_ADDRESS]-(:Address) return count(r)"
+        with self.driver.session(database=database) as session:
+            r = session.run(cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_pet_to_toy_relationship_counts(self) -> None:
+        cypher = "match (:Pet)-[r:PLAYS_WITH]-(:Toy) return count(r)"
+        with self.driver.session(database=database) as session:
+            r = session.run(cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_constraints_present(self) -> None:
+        cypher = "show constraints yield name return name"
+        with self.driver.session(database=database) as session:
+            r = set(session.run(cypher).value())
+            self.assertEqual(
+                {"person_name", "toy_name", "address_address", "pet_name"}, r
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/neo4j_runway/tests/test_pyingest_dataframe.py
+++ b/neo4j_runway/tests/test_pyingest_dataframe.py
@@ -128,8 +128,8 @@ class TestPyIngestLoadDataFrame(unittest.TestCase):
     def test_constraints_present(self) -> None:
         cypher = "show constraints yield name return name"
         with self.driver.session(database=os.environ.get("NEO4J_DATABASE")) as session:
-            r = session.run(cypher).value()
-            self.assertEqual(["person_name", "toy_name"], r)
+            r = set(session.run(cypher).value())
+            self.assertEqual({"person_name", "toy_name"}, r)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
add parameters to select batch size and load csv method [api or browser], tested

if a user wants to use the load csv code from the browser, this can be indicated and ":auto" will be appended to the ingestion statements. Otherwise it will assume that the user is loading via an api / driver.