### PR TITLE
from_arrows property uniqueness no longer in caption, tested

### DIFF
--- a/neo4j_runway/objects/node.py
+++ b/neo4j_runway/objects/node.py
@@ -103,39 +103,8 @@ class Node(BaseModel):
         """
 
         props = [
-            cls._parse_arrows_property(
-                arrows_property={k: v}, arrows_node_caption=arrows_node.caption
-            )
+            Property.from_arrows(arrows_property={k: v}, caption=arrows_node.caption)
             for k, v in arrows_node.properties.items()
         ]
         # support only single labels for now, take first label
         return cls(label=arrows_node.labels[0], properties=props)
-
-    @staticmethod
-    def _parse_arrows_property(
-        arrows_property: Dict[str, str], arrows_node_caption: str
-    ) -> Property:
-        """
-        Parse the arrows property representation into a standard Property model.
-        Unique property names are stored in the nodes caption as a comma-separated list: List<str>.
-        Arrow property values are formatted as <csv_mapping> | <python_type>.
-        """
-
-        if "|" in list(arrows_property.values())[0]:
-            csv_mapping, python_type = [
-                x.strip() for x in list(arrows_property.values())[0].split("|")
-            ]
-        else:
-            csv_mapping = list(arrows_property.values())[0]
-            python_type = "unknown"
-
-        is_unique = list(arrows_property.keys())[0] in [
-            x.strip() for x in arrows_node_caption.split(",")
-        ]
-
-        return Property(
-            name=list(arrows_property.keys())[0],
-            csv_mapping=csv_mapping,
-            type=python_type,
-            is_unique=is_unique,
-        )

--- a/neo4j_runway/objects/property.py
+++ b/neo4j_runway/objects/property.py
@@ -61,3 +61,35 @@ class Property(BaseModel):
         The Neo4j property type.
         """
         return TYPES_MAP_PYTHON_KEYS[self.type]
+
+    @classmethod
+    def from_arrows(cls, arrows_property: Dict[str, str], caption: str = "") -> None:
+        """
+        Parse the arrows property representation into a standard Property model.
+        Arrow property values are formatted as <csv_mapping> | <python_type> | <unique>.
+        """
+
+        if "|" in list(arrows_property.values())[0]:
+            prop_props = [
+                x.strip() for x in list(arrows_property.values())[0].split("|")
+            ]
+            csv_mapping = prop_props[0]
+            python_type = prop_props[1]
+            is_unique = "unique" in prop_props
+        else:
+            csv_mapping = list(arrows_property.values())[0]
+            python_type = "unknown"
+            is_unique = False
+
+        # support identifying uniqueness in caption for now, this will be depreciated.
+        if caption:
+            is_unique = list(arrows_property.keys())[0] in [
+                x.strip() for x in caption.split(",")
+            ]
+
+        return cls(
+            name=list(arrows_property.keys())[0],
+            csv_mapping=csv_mapping,
+            type=python_type,
+            is_unique=is_unique,
+        )

--- a/neo4j_runway/objects/relationship.py
+++ b/neo4j_runway/objects/relationship.py
@@ -112,7 +112,9 @@ class Relationship(BaseModel):
         """
 
         props = [
-            cls._parse_arrows_property(arrows_property={k: v})
+            Property.from_arrows(
+                arrows_property={k: v}
+            )
             for k, v in arrows_relationship.properties.items()
         ]
         return cls(
@@ -120,28 +122,4 @@ class Relationship(BaseModel):
             source=node_id_label_map[arrows_relationship.fromId],
             target=node_id_label_map[arrows_relationship.toId],
             properties=props,
-        )
-
-    def _parse_arrows_property(arrows_property: Dict[str, str]) -> Property:
-        """
-        Parse the arrows property representation into a standard Property model.
-        Unique property names are unable to be identified and will default to False.
-        Arrow property values are formatted as <csv_mapping> | <python_type>.
-        """
-
-        if "|" in list(arrows_property.values())[0]:
-            csv_mapping, python_type = [
-                x.strip() for x in list(arrows_property.values())[0].split("|")
-            ]
-        else:
-            csv_mapping = list(arrows_property.values())[0]
-            python_type = "unknown"
-
-        is_unique = False
-
-        return Property(
-            name=list(arrows_property.keys())[0],
-            csv_mapping=csv_mapping,
-            type=python_type,
-            is_unique=is_unique,
         )

--- a/neo4j_runway/tests/resources/people-pets-arrows-for-load-csv.json
+++ b/neo4j_runway/tests/resources/people-pets-arrows-for-load-csv.json
@@ -59,12 +59,12 @@
         "x": 209.43364843656647,
         "y": -279.86295267473423
       },
-      "caption": "name",
+      "caption": "",
       "labels": [
         "Person"
       ],
       "properties": {
-        "name": "name | str",
+        "name": "name | str | unique",
         "age": "age | int"
       },
       "style": {
@@ -78,12 +78,12 @@
         "x": 572.2331024161601,
         "y": -180.66469660748788
       },
-      "caption": "address",
+      "caption": "",
       "labels": [
         "Address"
       ],
       "properties": {
-        "address": "address | str"
+        "address": "address | str | unique"
       },
       "style": {
         "node-color": "#fda1ff",
@@ -96,12 +96,12 @@
         "x": 572.2331024161601,
         "y": -379.06120874198064
       },
-      "caption": "name",
+      "caption": "",
       "labels": [
         "Pet"
       ],
       "properties": {
-        "name": "pet_name | str",
+        "name": "pet_name | str | unique",
         "kind": "pet | str"
       },
       "style": {
@@ -114,12 +114,12 @@
         "x": 900.26386884154,
         "y": -279.86295267473423
       },
-      "caption": "name",
+      "caption": "",
       "labels": [
         "Toy"
       ],
       "properties": {
-        "name": "toy | str",
+        "name": "toy | str | unique",
         "kind": "toy_type | str"
       },
       "style": {

--- a/neo4j_runway/tests/test_node.py
+++ b/neo4j_runway/tests/test_node.py
@@ -75,44 +75,7 @@ class TestNode(unittest.TestCase):
         self.assertEqual(node_from_arrows.properties[0].type, "str")
         self.assertEqual(node_from_arrows.properties[1].type, "int")
 
-    def test_parse_arrows_property(self) -> None:
-        """
-        Test the parsing of an arrows property to a standard property model.
-        """
-
-        to_parse = {"name": "name_col | str"}  # passes
-        to_parse2 = {"notUnique": "nu_col|str"}  # passes
-        to_parse3 = {
-            "other": "other_col | STRING"
-        }  # should pass, but replace the STRING type with str
-
-        caption = "name, other, thisOne"
-
-        parsed_prop1 = Node._parse_arrows_property(to_parse, caption)
-        parsed_prop2 = Node._parse_arrows_property(to_parse2, caption)
-        parsed_prop3 = Node._parse_arrows_property(to_parse3, caption)
-
-        prop1 = Property(
-            name="name", type="str", csv_mapping="name_col", is_unique=True
-        )
-        prop2 = Property(
-            name="notUnique", type="str", csv_mapping="nu_col", is_unique=False
-        )
-        prop3 = Property(
-            name="other", type="str", csv_mapping="other_col", is_unique=True
-        )
-
-        self.assertEqual(parsed_prop1, prop1)
-        self.assertEqual(parsed_prop2, prop2)
-        self.assertEqual(parsed_prop3, prop3)
-
-        to_parse4 = {"name": "name_col"}
-        prop4 = Property(
-            name="name", type="unknown", csv_mapping="name_col", is_unique=False
-        )
-
-        self.assertEqual(Node._parse_arrows_property(to_parse4, ""), prop4)
-        self.assertEqual(Node._parse_arrows_property(to_parse4, " adfwe"), prop4)
+   
 
 
 if __name__ == "__main__":

--- a/neo4j_runway/tests/test_property.py
+++ b/neo4j_runway/tests/test_property.py
@@ -71,6 +71,44 @@ class TestProperty(unittest.TestCase):
                 v,
             )
 
+    def test_parse_arrows_property(self) -> None:
+        """
+        Test the parsing of an arrows property to a standard property model.
+        """
+
+        to_parse = {"name": "name_col | str | unique"}  # passes
+        to_parse2 = {"notUnique": "nu_col|str"}  # passes
+        to_parse3 = {
+            "other": "other_col | STRING | unique"
+        }  # should pass, but replace the STRING type with str
+
+        caption = "name, other, thisOne"
+
+        parsed_prop1 = Property.from_arrows(to_parse, caption)
+        parsed_prop2 = Property.from_arrows(to_parse2, caption)
+        parsed_prop3 = Property.from_arrows(to_parse3)
+
+        prop1 = Property(
+            name="name", type="str", csv_mapping="name_col", is_unique=True
+        )
+        prop2 = Property(
+            name="notUnique", type="str", csv_mapping="nu_col", is_unique=False
+        )
+        prop3 = Property(
+            name="other", type="str", csv_mapping="other_col", is_unique=True
+        )
+
+        self.assertEqual(parsed_prop1, prop1)
+        self.assertEqual(parsed_prop2, prop2)
+        self.assertEqual(parsed_prop3, prop3)
+
+        to_parse4 = {"name": "name_col"}
+        prop4 = Property(
+            name="name", type="unknown", csv_mapping="name_col", is_unique=False
+        )
+
+        self.assertEqual(Property.from_arrows(to_parse4, ""), prop4)
+        self.assertEqual(Property.from_arrows(to_parse4, " adfwe"), prop4)
 
 if __name__ == "__main__":
     unittest.main()

--- a/neo4j_runway/tests/test_relationship.py
+++ b/neo4j_runway/tests/test_relationship.py
@@ -117,42 +117,6 @@ class TestRelationship(unittest.TestCase):
         self.assertEqual(relationship_from_arrows.properties[0].type, "float")
         self.assertEqual(relationship_from_arrows.properties[1].type, "bool")
 
-    def test_parse_arrows_property(self) -> None:
-        """
-        Test the parsing of an arrows property to a standard property model.
-        """
-
-        to_parse = {"name": "name_col | str"}  # passes
-        to_parse2 = {"notUnique": "nu_col|str"}  # passes
-        to_parse3 = {
-            "other": "other_col | STRING"
-        }  # should pass, but replace the STRING type with str
-
-        parsed_prop1 = Relationship._parse_arrows_property(to_parse)
-        parsed_prop2 = Relationship._parse_arrows_property(to_parse2)
-        parsed_prop3 = Relationship._parse_arrows_property(to_parse3)
-
-        prop1 = Property(
-            name="name", type="str", csv_mapping="name_col", is_unique=False
-        )
-        prop2 = Property(
-            name="notUnique", type="str", csv_mapping="nu_col", is_unique=False
-        )
-        prop3 = Property(
-            name="other", type="str", csv_mapping="other_col", is_unique=False
-        )
-
-        self.assertEqual(parsed_prop1, prop1)
-        self.assertEqual(parsed_prop2, prop2)
-        self.assertEqual(parsed_prop3, prop3)
-
-        to_parse4 = {"name": "name_col"}
-        prop4 = Property(
-            name="name", type="unknown", csv_mapping="name_col", is_unique=False
-        )
-
-        self.assertEqual(Relationship._parse_arrows_property(to_parse4), prop4)
-        self.assertEqual(Relationship._parse_arrows_property(to_parse4), prop4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
arrows property uniqueness can now be indicated in the pipe-separated list instead of the caption. Indicating uniqueness in the caption will be depreciated in future versions.