### PR TITLE
fix load_csv bug, move property uniqueness in arrows model

### DIFF
--- a/neo4j_runway/objects/node.py
+++ b/neo4j_runway/objects/node.py
@@ -103,39 +103,8 @@ class Node(BaseModel):
         """
 
         props = [
-            cls._parse_arrows_property(
-                arrows_property={k: v}, arrows_node_caption=arrows_node.caption
-            )
+            Property.from_arrows(arrows_property={k: v}, caption=arrows_node.caption)
             for k, v in arrows_node.properties.items()
         ]
         # support only single labels for now, take first label
         return cls(label=arrows_node.labels[0], properties=props)
-
-    @staticmethod
-    def _parse_arrows_property(
-        arrows_property: Dict[str, str], arrows_node_caption: str
-    ) -> Property:
-        """
-        Parse the arrows property representation into a standard Property model.
-        Unique property names are stored in the nodes caption as a comma-separated list: List<str>.
-        Arrow property values are formatted as <csv_mapping> | <python_type>.
-        """
-
-        if "|" in list(arrows_property.values())[0]:
-            csv_mapping, python_type = [
-                x.strip() for x in list(arrows_property.values())[0].split("|")
-            ]
-        else:
-            csv_mapping = list(arrows_property.values())[0]
-            python_type = "unknown"
-
-        is_unique = list(arrows_property.keys())[0] in [
-            x.strip() for x in arrows_node_caption.split(",")
-        ]
-
-        return Property(
-            name=list(arrows_property.keys())[0],
-            csv_mapping=csv_mapping,
-            type=python_type,
-            is_unique=is_unique,
-        )

--- a/neo4j_runway/objects/property.py
+++ b/neo4j_runway/objects/property.py
@@ -61,3 +61,35 @@ class Property(BaseModel):
         The Neo4j property type.
         """
         return TYPES_MAP_PYTHON_KEYS[self.type]
+
+    @classmethod
+    def from_arrows(cls, arrows_property: Dict[str, str], caption: str = "") -> None:
+        """
+        Parse the arrows property representation into a standard Property model.
+        Arrow property values are formatted as <csv_mapping> | <python_type> | <unique>.
+        """
+
+        if "|" in list(arrows_property.values())[0]:
+            prop_props = [
+                x.strip() for x in list(arrows_property.values())[0].split("|")
+            ]
+            csv_mapping = prop_props[0]
+            python_type = prop_props[1]
+            is_unique = "unique" in prop_props
+        else:
+            csv_mapping = list(arrows_property.values())[0]
+            python_type = "unknown"
+            is_unique = False
+
+        # support identifying uniqueness in caption for now, this will be depreciated.
+        if caption:
+            is_unique = list(arrows_property.keys())[0] in [
+                x.strip() for x in caption.split(",")
+            ]
+
+        return cls(
+            name=list(arrows_property.keys())[0],
+            csv_mapping=csv_mapping,
+            type=python_type,
+            is_unique=is_unique,
+        )

--- a/neo4j_runway/objects/relationship.py
+++ b/neo4j_runway/objects/relationship.py
@@ -112,7 +112,9 @@ class Relationship(BaseModel):
         """
 
         props = [
-            cls._parse_arrows_property(arrows_property={k: v})
+            Property.from_arrows(
+                arrows_property={k: v}
+            )
             for k, v in arrows_relationship.properties.items()
         ]
         return cls(
@@ -120,28 +122,4 @@ class Relationship(BaseModel):
             source=node_id_label_map[arrows_relationship.fromId],
             target=node_id_label_map[arrows_relationship.toId],
             properties=props,
-        )
-
-    def _parse_arrows_property(arrows_property: Dict[str, str]) -> Property:
-        """
-        Parse the arrows property representation into a standard Property model.
-        Unique property names are unable to be identified and will default to False.
-        Arrow property values are formatted as <csv_mapping> | <python_type>.
-        """
-
-        if "|" in list(arrows_property.values())[0]:
-            csv_mapping, python_type = [
-                x.strip() for x in list(arrows_property.values())[0].split("|")
-            ]
-        else:
-            csv_mapping = list(arrows_property.values())[0]
-            python_type = "unknown"
-
-        is_unique = False
-
-        return Property(
-            name=list(arrows_property.keys())[0],
-            csv_mapping=csv_mapping,
-            type=python_type,
-            is_unique=is_unique,
         )

--- a/neo4j_runway/tests/resources/ingestion_generation_answers.py
+++ b/neo4j_runway/tests/resources/ingestion_generation_answers.py
@@ -28,7 +28,7 @@ MATCH (source:NodeA {{uniqueProp1: row.unique_prop_1, uniqueProp3: row.unique_pr
 MATCH (target:NodeB {{uniqueProp2: row.unique_prop_2}})
 MERGE (source)-[n:HAS_RELATIONSHIP]->(target)
 {set_properties_rel_1}"""
-merge_relationship_load_csv = f"""LOAD CSV WITH HEADERS FROM 'file:///test.csv' as row
+merge_relationship_load_csv = f""":auto LOAD CSV WITH HEADERS FROM 'file:///test.csv' as row
 CALL {{
     WITH row
     MATCH (source:NodeA {{uniqueProp1: row.unique_prop_1, uniqueProp3: row.unique_prop_3}})

--- a/neo4j_runway/tests/resources/people-pets-arrows-for-load-csv.json
+++ b/neo4j_runway/tests/resources/people-pets-arrows-for-load-csv.json
@@ -1,0 +1,166 @@
+{
+  "style": {
+    "font-family": "sans-serif",
+    "background-color": "#ffffff",
+    "background-image": "",
+    "background-size": "100%",
+    "node-color": "#ffffff",
+    "border-width": 4,
+    "border-color": "#000000",
+    "radius": 50,
+    "node-padding": 5,
+    "node-margin": 2,
+    "outside-position": "auto",
+    "node-icon-image": "",
+    "node-background-image": "",
+    "icon-position": "inside",
+    "icon-size": 64,
+    "caption-position": "inside",
+    "caption-max-width": 200,
+    "caption-color": "#000000",
+    "caption-font-size": 50,
+    "caption-font-weight": "normal",
+    "label-position": "inside",
+    "label-display": "pill",
+    "label-color": "#000000",
+    "label-background-color": "#ffffff",
+    "label-border-color": "#000000",
+    "label-border-width": 4,
+    "label-font-size": 40,
+    "label-padding": 5,
+    "label-margin": 4,
+    "directionality": "directed",
+    "detail-position": "inline",
+    "detail-orientation": "parallel",
+    "arrow-width": 5,
+    "arrow-color": "#000000",
+    "margin-start": 5,
+    "margin-end": 5,
+    "margin-peer": 20,
+    "attachment-start": "normal",
+    "attachment-end": "normal",
+    "relationship-icon-image": "",
+    "type-color": "#000000",
+    "type-background-color": "#ffffff",
+    "type-border-color": "#000000",
+    "type-border-width": 0,
+    "type-font-size": 16,
+    "type-padding": 5,
+    "property-position": "outside",
+    "property-alignment": "colon",
+    "property-color": "#000000",
+    "property-font-size": 16,
+    "property-font-weight": "normal"
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "position": {
+        "x": 209.43364843656647,
+        "y": -279.86295267473423
+      },
+      "caption": "name",
+      "labels": [
+        "Person"
+      ],
+      "properties": {
+        "name": "name | str",
+        "age": "age | int"
+      },
+      "style": {
+        "outside-position": "bottom",
+        "node-color": "#68bc00"
+      }
+    },
+    {
+      "id": "n1",
+      "position": {
+        "x": 572.2331024161601,
+        "y": -180.66469660748788
+      },
+      "caption": "address",
+      "labels": [
+        "Address"
+      ],
+      "properties": {
+        "address": "address | str"
+      },
+      "style": {
+        "node-color": "#fda1ff",
+        "outside-position": "bottom"
+      }
+    },
+    {
+      "id": "n2",
+      "position": {
+        "x": 572.2331024161601,
+        "y": -379.06120874198064
+      },
+      "caption": "name",
+      "labels": [
+        "Pet"
+      ],
+      "properties": {
+        "name": "pet_name | str",
+        "kind": "pet | str"
+      },
+      "style": {
+        "node-color": "#68ccca"
+      }
+    },
+    {
+      "id": "n3",
+      "position": {
+        "x": 900.26386884154,
+        "y": -279.86295267473423
+      },
+      "caption": "name",
+      "labels": [
+        "Toy"
+      ],
+      "properties": {
+        "name": "toy | str",
+        "kind": "toy_type | str"
+      },
+      "style": {
+        "node-color": "#aea1ff",
+        "outside-position": "bottom"
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "id": "n0",
+      "fromId": "n0",
+      "toId": "n1",
+      "type": "HAS_ADDRESS",
+      "properties": {},
+      "style": {
+        "detail-orientation": "horizontal",
+        "detail-position": "inline"
+      }
+    },
+    {
+      "id": "n2",
+      "fromId": "n0",
+      "toId": "n2",
+      "type": "HAS_PET",
+      "properties": {},
+      "style": {
+        "detail-orientation": "horizontal",
+        "detail-position": "inline"
+      }
+    },
+    {
+      "id": "n3",
+      "fromId": "n2",
+      "toId": "n3",
+      "type": "PLAYS_WITH",
+      "properties": {},
+      "style": {
+        "detail-orientation": "horizontal",
+        "detail-position": "inline"
+      }
+    }
+  ]
+}

--- a/neo4j_runway/tests/resources/people-pets-arrows-for-load-csv.json
+++ b/neo4j_runway/tests/resources/people-pets-arrows-for-load-csv.json
@@ -59,12 +59,12 @@
         "x": 209.43364843656647,
         "y": -279.86295267473423
       },
-      "caption": "name",
+      "caption": "",
       "labels": [
         "Person"
       ],
       "properties": {
-        "name": "name | str",
+        "name": "name | str | unique",
         "age": "age | int"
       },
       "style": {
@@ -78,12 +78,12 @@
         "x": 572.2331024161601,
         "y": -180.66469660748788
       },
-      "caption": "address",
+      "caption": "",
       "labels": [
         "Address"
       ],
       "properties": {
-        "address": "address | str"
+        "address": "address | str | unique"
       },
       "style": {
         "node-color": "#fda1ff",
@@ -96,12 +96,12 @@
         "x": 572.2331024161601,
         "y": -379.06120874198064
       },
-      "caption": "name",
+      "caption": "",
       "labels": [
         "Pet"
       ],
       "properties": {
-        "name": "pet_name | str",
+        "name": "pet_name | str | unique",
         "kind": "pet | str"
       },
       "style": {
@@ -114,12 +114,12 @@
         "x": 900.26386884154,
         "y": -279.86295267473423
       },
-      "caption": "name",
+      "caption": "",
       "labels": [
         "Toy"
       ],
       "properties": {
-        "name": "toy | str",
+        "name": "toy | str | unique",
         "kind": "toy_type | str"
       },
       "style": {

--- a/neo4j_runway/tests/test_ingest_generation.py
+++ b/neo4j_runway/tests/test_ingest_generation.py
@@ -181,7 +181,9 @@ class TestIngestCodeGneration(unittest.TestCase):
         """
 
         self.assertEqual(
-            generate_merge_node_load_csv_clause(node=self.node_b, csv_name="test.csv"),
+            generate_merge_node_load_csv_clause(
+                node=self.node_b, csv_name="test.csv", method="api"
+            ),
             merge_node_load_csv_b,
         )
 
@@ -210,6 +212,7 @@ class TestIngestCodeGneration(unittest.TestCase):
                 source_node=self.node_a,
                 target_node=self.node_b,
                 csv_name="test.csv",
+                method="browser",
                 batch_size=50,
             ),
             merge_relationship_load_csv,

--- a/neo4j_runway/tests/test_load_csv_via_api.py
+++ b/neo4j_runway/tests/test_load_csv_via_api.py
@@ -1,0 +1,147 @@
+import os
+import unittest
+
+from dotenv import load_dotenv
+from neo4j import GraphDatabase
+from neo4j.exceptions import AuthError
+
+from ..utils import test_database_connection
+from ..ingestion import IngestionGenerator
+from ..objects import DataModel
+
+load_dotenv()
+
+# These credentials are for the dummy data testing only. Do NOT use the same credentials here for production graphs.
+username = os.environ.get("NEO4J_USERNAME")
+password = os.environ.get("NEO4J_PASSWORD")
+uri = os.environ.get("NEO4J_URI")
+database = os.environ.get("NEO4J_DATABASE")
+
+
+class TestLoadCSVViaAPI(unittest.TestCase):
+    """
+    Steps:
+        1. Ensure local instance of Neo4j is available.
+        2. Generate the LOAD CSV code with an imported data model from arrows.app.
+        3. Load the data into a local instance of Neo4j. The csv is located at imports/ of the local instance.
+        4. query local graph to ensure data loaded properly.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.driver = GraphDatabase.driver(
+            uri=uri,
+            auth=(username, password),
+        )
+
+        connection_info = test_database_connection(
+            credentials={
+                "uri": uri,
+                "username": username,
+                "password": password,
+            }
+        )
+
+        if not connection_info["valid"]:
+            raise AuthError(connection_info["message"])
+
+        # clear all data in the database
+        with cls.driver.session(database=database) as session:
+            session.run(
+                """
+                        match (n)-[r]-()
+                        detach delete n, r
+                        ;
+                        """
+            )
+            session.run(
+                """
+                        match (n)
+                        delete n
+                        ;
+                        """
+            )
+            session.run(
+                """
+                        CALL apoc.schema.assert({}, {})
+                        ;
+                        """
+            )
+
+        data_model = DataModel.from_arrows(
+            "neo4j_runway/tests/resources/people-pets-arrows-for-load-csv.json"
+        )
+
+        gen = IngestionGenerator(
+            data_model=data_model,
+            username=username,
+            password=password,
+            uri=uri,
+            database=database,
+            csv_name="pets-arrows.csv",
+        )
+
+        load_csv_cypher = gen.generate_load_csv_string(method="api")
+
+        # skip last "query" since it is an empty string
+        for query in load_csv_cypher.split(";")[:-1]:
+            with cls.driver.session(database=database) as session:
+                session.run(query=query)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.driver.close()
+
+    def test_person_node_count(self) -> None:
+        person_cypher = "match (p:Person) return count(p)"
+        with self.driver.session(database=database) as session:
+            r = session.run(person_cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_pet_node_count(self) -> None:
+        pet_cypher = "match (p:Pet) return count(p)"
+        with self.driver.session(database=database) as session:
+            r = session.run(pet_cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_toy_node_count(self) -> None:
+        toy_cypher = "match (p:Toy) return count(p)"
+        with self.driver.session(database=database) as session:
+            r = session.run(toy_cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_address_node_count(self) -> None:
+        address_cypher = "match (p:Address) return count(p)"
+        with self.driver.session(database=database) as session:
+            r = session.run(address_cypher).single().value()
+            self.assertEqual(3, r)
+
+    def test_person_to_pet_relationship_counts(self) -> None:
+        cypher = "match (:Person)-[r:HAS_PET]-(:Pet) return count(r)"
+        with self.driver.session(database=database) as session:
+            r = session.run(cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_person_to_address_relationship_counts(self) -> None:
+        cypher = "match (:Person)-[r:HAS_ADDRESS]-(:Address) return count(r)"
+        with self.driver.session(database=database) as session:
+            r = session.run(cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_pet_to_toy_relationship_counts(self) -> None:
+        cypher = "match (:Pet)-[r:PLAYS_WITH]-(:Toy) return count(r)"
+        with self.driver.session(database=database) as session:
+            r = session.run(cypher).single().value()
+            self.assertEqual(5, r)
+
+    def test_constraints_present(self) -> None:
+        cypher = "show constraints yield name return name"
+        with self.driver.session(database=database) as session:
+            r = set(session.run(cypher).value())
+            self.assertEqual(
+                {"person_name", "toy_name", "address_address", "pet_name"}, r
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/neo4j_runway/tests/test_node.py
+++ b/neo4j_runway/tests/test_node.py
@@ -75,44 +75,7 @@ class TestNode(unittest.TestCase):
         self.assertEqual(node_from_arrows.properties[0].type, "str")
         self.assertEqual(node_from_arrows.properties[1].type, "int")
 
-    def test_parse_arrows_property(self) -> None:
-        """
-        Test the parsing of an arrows property to a standard property model.
-        """
-
-        to_parse = {"name": "name_col | str"}  # passes
-        to_parse2 = {"notUnique": "nu_col|str"}  # passes
-        to_parse3 = {
-            "other": "other_col | STRING"
-        }  # should pass, but replace the STRING type with str
-
-        caption = "name, other, thisOne"
-
-        parsed_prop1 = Node._parse_arrows_property(to_parse, caption)
-        parsed_prop2 = Node._parse_arrows_property(to_parse2, caption)
-        parsed_prop3 = Node._parse_arrows_property(to_parse3, caption)
-
-        prop1 = Property(
-            name="name", type="str", csv_mapping="name_col", is_unique=True
-        )
-        prop2 = Property(
-            name="notUnique", type="str", csv_mapping="nu_col", is_unique=False
-        )
-        prop3 = Property(
-            name="other", type="str", csv_mapping="other_col", is_unique=True
-        )
-
-        self.assertEqual(parsed_prop1, prop1)
-        self.assertEqual(parsed_prop2, prop2)
-        self.assertEqual(parsed_prop3, prop3)
-
-        to_parse4 = {"name": "name_col"}
-        prop4 = Property(
-            name="name", type="unknown", csv_mapping="name_col", is_unique=False
-        )
-
-        self.assertEqual(Node._parse_arrows_property(to_parse4, ""), prop4)
-        self.assertEqual(Node._parse_arrows_property(to_parse4, " adfwe"), prop4)
+   
 
 
 if __name__ == "__main__":

--- a/neo4j_runway/tests/test_property.py
+++ b/neo4j_runway/tests/test_property.py
@@ -71,6 +71,44 @@ class TestProperty(unittest.TestCase):
                 v,
             )
 
+    def test_parse_arrows_property(self) -> None:
+        """
+        Test the parsing of an arrows property to a standard property model.
+        """
+
+        to_parse = {"name": "name_col | str | unique"}  # passes
+        to_parse2 = {"notUnique": "nu_col|str"}  # passes
+        to_parse3 = {
+            "other": "other_col | STRING | unique"
+        }  # should pass, but replace the STRING type with str
+
+        caption = "name, other, thisOne"
+
+        parsed_prop1 = Property.from_arrows(to_parse, caption)
+        parsed_prop2 = Property.from_arrows(to_parse2, caption)
+        parsed_prop3 = Property.from_arrows(to_parse3)
+
+        prop1 = Property(
+            name="name", type="str", csv_mapping="name_col", is_unique=True
+        )
+        prop2 = Property(
+            name="notUnique", type="str", csv_mapping="nu_col", is_unique=False
+        )
+        prop3 = Property(
+            name="other", type="str", csv_mapping="other_col", is_unique=True
+        )
+
+        self.assertEqual(parsed_prop1, prop1)
+        self.assertEqual(parsed_prop2, prop2)
+        self.assertEqual(parsed_prop3, prop3)
+
+        to_parse4 = {"name": "name_col"}
+        prop4 = Property(
+            name="name", type="unknown", csv_mapping="name_col", is_unique=False
+        )
+
+        self.assertEqual(Property.from_arrows(to_parse4, ""), prop4)
+        self.assertEqual(Property.from_arrows(to_parse4, " adfwe"), prop4)
 
 if __name__ == "__main__":
     unittest.main()

--- a/neo4j_runway/tests/test_pyingest_dataframe.py
+++ b/neo4j_runway/tests/test_pyingest_dataframe.py
@@ -128,8 +128,8 @@ class TestPyIngestLoadDataFrame(unittest.TestCase):
     def test_constraints_present(self) -> None:
         cypher = "show constraints yield name return name"
         with self.driver.session(database=os.environ.get("NEO4J_DATABASE")) as session:
-            r = session.run(cypher).value()
-            self.assertEqual(["person_name", "toy_name"], r)
+            r = set(session.run(cypher).value())
+            self.assertEqual({"person_name", "toy_name"}, r)
 
 
 if __name__ == "__main__":

--- a/neo4j_runway/tests/test_relationship.py
+++ b/neo4j_runway/tests/test_relationship.py
@@ -117,42 +117,6 @@ class TestRelationship(unittest.TestCase):
         self.assertEqual(relationship_from_arrows.properties[0].type, "float")
         self.assertEqual(relationship_from_arrows.properties[1].type, "bool")
 
-    def test_parse_arrows_property(self) -> None:
-        """
-        Test the parsing of an arrows property to a standard property model.
-        """
-
-        to_parse = {"name": "name_col | str"}  # passes
-        to_parse2 = {"notUnique": "nu_col|str"}  # passes
-        to_parse3 = {
-            "other": "other_col | STRING"
-        }  # should pass, but replace the STRING type with str
-
-        parsed_prop1 = Relationship._parse_arrows_property(to_parse)
-        parsed_prop2 = Relationship._parse_arrows_property(to_parse2)
-        parsed_prop3 = Relationship._parse_arrows_property(to_parse3)
-
-        prop1 = Property(
-            name="name", type="str", csv_mapping="name_col", is_unique=False
-        )
-        prop2 = Property(
-            name="notUnique", type="str", csv_mapping="nu_col", is_unique=False
-        )
-        prop3 = Property(
-            name="other", type="str", csv_mapping="other_col", is_unique=False
-        )
-
-        self.assertEqual(parsed_prop1, prop1)
-        self.assertEqual(parsed_prop2, prop2)
-        self.assertEqual(parsed_prop3, prop3)
-
-        to_parse4 = {"name": "name_col"}
-        prop4 = Property(
-            name="name", type="unknown", csv_mapping="name_col", is_unique=False
-        )
-
-        self.assertEqual(Relationship._parse_arrows_property(to_parse4), prop4)
-        self.assertEqual(Relationship._parse_arrows_property(to_parse4), prop4)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "neo4j-runway"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Python library that contains tools for data discovery, data model generation and ingestion for the Neo4j graph database."
 authors = ["Alex Gilmore", "Jason Booth", "Dan Bukowski"]
 license = "MIT"


### PR DESCRIPTION
load_csv code generation now has an argument indicating whether it will be used by an api or in Neo4j browser.
Arrows property uniquess should now be indicated in the pipe-separated list of a property instead of the node caption.