### PR TITLE
Data model validation fix error reporting

### DIFF
--- a/neo4j_runway/models/core/node.py
+++ b/neo4j_runway/models/core/node.py
@@ -207,7 +207,9 @@ class Node(BaseModel):
 
         if len(self.node_keys) == 1:
             # only write error if this node is NOT also labeled as unique
-            if self.node_keys[0].name not in [prop.name for prop in self.unique_properties]:
+            if self.node_keys[0].name not in [
+                prop.name for prop in self.unique_properties
+            ]:
                 errors.append(
                     f"The node {self.label} has a node key on only one property {self.node_keys[0].name}. Node keys must exist on two or more properties."
                 )

--- a/neo4j_runway/models/core/node.py
+++ b/neo4j_runway/models/core/node.py
@@ -79,7 +79,7 @@ class Node(BaseModel):
 
         Returns
         -------
-        List[str]
+        List[Property]
             A list of unique properties.
         """
 
@@ -206,9 +206,11 @@ class Node(BaseModel):
                 )
 
         if len(self.node_keys) == 1:
-            errors.append(
-                f"The node {self.label} has a node key on only one property {self.node_keys[0].name}. Node keys must exist on two or more properties."
-            )
+            # only write error if this node is NOT also labeled as unique
+            if self.node_keys[0].name not in [prop.name for prop in self.unique_properties]:
+                errors.append(
+                    f"The node {self.label} has a node key on only one property {self.node_keys[0].name}. Node keys must exist on two or more properties."
+                )
         return errors
 
     def to_arrows(self, x_position: float, y_position: float) -> ArrowsNode:

--- a/neo4j_runway/models/core/relationship.py
+++ b/neo4j_runway/models/core/relationship.py
@@ -69,7 +69,7 @@ class Relationship(BaseModel):
         return {prop.name: prop.csv_mapping for prop in self.properties}
 
     @property
-    def unique_properties(self) -> List[str]:
+    def unique_properties(self) -> List[Property]:
         """
         The relationship's unique properties.
         """
@@ -163,13 +163,15 @@ class Relationship(BaseModel):
                     )
                 if prop.is_unique and prop.part_of_key:
                     errors.append(
-                        f"The relationship {self.type} has the property {prop.name} identified as unique and a node key. Assume uniqueness and set part_of_key to False."
+                        f"The relationship {self.type} has the property {prop.name} identified as unique and a relationship key. Assume uniqueness and set part_of_key to False."
                     )
 
         if len(self.relationship_keys) == 1:
-            errors.append(
-                f"The relationship {self.type} has a relationship key on only one property {self.relationship_keys[0].name}. Relationship keys must exist on two or more properties."
-            )
+            # only write error if this node is NOT also labeled as unique
+            if self.relationship_keys[0].name not in [prop.name for prop in self.unique_properties]:
+                errors.append(
+                    f"The relationship {self.type} has a relationship key on only one property {self.relationship_keys[0].name}. Relationship keys must exist on two or more properties."
+                )
         return errors
 
     def to_arrows(self) -> ArrowsRelationship:

--- a/neo4j_runway/models/core/relationship.py
+++ b/neo4j_runway/models/core/relationship.py
@@ -168,7 +168,9 @@ class Relationship(BaseModel):
 
         if len(self.relationship_keys) == 1:
             # only write error if this node is NOT also labeled as unique
-            if self.relationship_keys[0].name not in [prop.name for prop in self.unique_properties]:
+            if self.relationship_keys[0].name not in [
+                prop.name for prop in self.unique_properties
+            ]:
                 errors.append(
                     f"The relationship {self.type} has a relationship key on only one property {self.relationship_keys[0].name}. Relationship keys must exist on two or more properties."
                 )


### PR DESCRIPTION
Sometimes errors would provide conflicting solutions. Wrote logic to avoid this.
- example: property is unique and node key AND only 1 node key declared. Prompt would say to find another property to make it a valid node key and also remove the node key label from the property.
